### PR TITLE
Update host.yaml to build from Fedora 29 content

### DIFF
--- a/compose-post.sh
+++ b/compose-post.sh
@@ -40,8 +40,8 @@ echo '%sudo        ALL=(ALL)       NOPASSWD: ALL' > /etc/sudoers.d/coreos-sudo-g
 
 # Nuke network.service from orbit
 # https://github.com/openshift/os/issues/117
-rm /etc/rc.d/init.d/network
-rm /etc/rc.d/rc*.d/*network
+#rm /etc/rc.d/init.d/network
+#rm /etc/rc.d/rc*.d/*network
 
 # And readahead https://bugzilla.redhat.com/show_bug.cgi?id=1594984
 # It's long dead upstream, we definitely don't want it.

--- a/host.yaml
+++ b/host.yaml
@@ -1,4 +1,4 @@
-ref: "fedora/28/x86_64/coreos"
+ref: "fedora/29/x86_64/coreos"
 repos:
 # - atomic-centos-continuous
 # - rhcos-continuous
@@ -8,10 +8,7 @@ repos:
 # - rhel-7.5-server-extras
 # - rhel-7.5-atomic
   - dustymabe-ignition
-  - dustymabe-docker
-  - fahc-rdgo
-  - fedora-28
-  - fedora-28-updates
+  - fedora-29
 install-langs:
  - en_US
 documentation: false
@@ -22,8 +19,8 @@ initramfs-args:
   - "--no-hostonly"
   - "--add"
   - "iscsi"
-automatic_version_prefix: "28"
-mutate-os-release: "28"
+automatic_version_prefix: "29"
+mutate-os-release: "29"
 # https://github.com/projectatomic/rpm-ostree/pull/1425
 machineid-compat: false
 postprocess-script: "compose-post.sh"
@@ -49,7 +46,7 @@ packages:
  # Release package
 #- redhat-release-coreos
 # https://github.com/coreos/fedora-coreos-tracker/issues/20
- - fedora-release-atomichost
+ - fedora-release-coreos
  # rpm-ostree
  - rpm-ostree nss-altfiles
  # SELinux
@@ -89,6 +86,7 @@ packages:
  - sudo coreutils less tar xz gzip bzip2 rsync tmux
  - nmap-ncat net-tools bind-utils strace
  - bash-completion
+ - hostname
  # Editors
  - vim-minimal nano
  # OpenShift


### PR DESCRIPTION
This commit brings additional changes such as:
- Requires only openshift custom repo, remaining
  repos not needed since required packages are available in F29.
- Install fedora-release-coreos instead of fedora-release-atomichost
- Specify explictly hostname since it longer get installed
  as dependency.
- /etc/rc.d/init.d/network and /etc/rc.d/rc*.d/*network files
  are not available. So, don't try to remove them.

Signed-off-by: Sinny Kumari <sinny@redhat.com>